### PR TITLE
Add the ability to have multiple confgens and nanorcs per session

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -88,3 +88,10 @@ confgen_arguments=[ [ "arg1", "arg2" ], ["arg1", "arg2", "arg3"] ]
 This will run the confgen script twice: once with arguments `["arg1", "arg2"]`, and once with arguments `["arg1", "arg2", "arg3"]`. `nanorc` will be run for each of outputs of the confgen script (in this example, two `nanorc` sessions would be run).
 
 You can have multiple `nanorc` runs per confgen script too: modify `nanorc_command_list` to be a list of lists of commands. The total number of `nanorc` runs will then be `len(confgen_arguments) * len(nanorc_command_list)`
+
+`pytest` will automatically generate names for each `(confgen_arguments, nanorc_command_list)` pair. You can provide more meaningful names by providing `confgen_arguments` and/or `nanorc_command_list` as a dictionary. Each key is the human-readable name of the instance, and the corresponding value is the list of arguments or commands. Eg, for two nanorc runs with different lengths, with names "longer" and "shorter":
+
+```python
+nanorc_command_list={ "longer": "boot init conf start 101 wait 1 resume wait 20 pause wait 1 stop wait 2 scrap terminate".split(),
+                      "shorter": "boot init conf start 101 wait 1 resume wait 10 pause wait 1 stop wait 2 scrap terminate".split() }
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,3 +73,15 @@ of the `run_nanorc` [fixture](https://docs.pytest.org/en/6.2.x/fixture.html#fixt
 * `data_files`:        list of [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path) with each of the HDF5 data files produced by the run
 * `log_files`:         list of [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path) with each of the log files produced by the run
 * `opmon_files`:       list of [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path) with each of the opmon json files produced by the run
+
+## Running multiple confgens/nanorc sessions
+
+You may want to run the same tests on the output of multiple confgens (eg, to check that the system works with a particular option both on and off). To do this, change `confgen_arguments` to be a list of _lists_ of arguments to your `confgen` script. Eg:
+
+```python
+confgen_arguments=[ [ "arg1", "arg2" ], ["arg1", "arg2", "arg3"] ]
+```
+
+This will run the confgen script twice: once with arguments `["arg1", "arg2"]`, and once with arguments `["arg1", "arg2", "arg3"]`. `nanorc` will be run for each of outputs of the confgen script (in this example, two `nanorc` sessions would be run).
+
+You can have multiple `nanorc` runs per confgen script too: modify `nanorc_command_list` to be a list of lists of commands. The total number of `nanorc` runs will then be `len(confgen_arguments) * len(nanorc_command_list)`

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,9 @@ Each test function's name must begin with `test_` and the function should take `
 of the `run_nanorc` [fixture](https://docs.pytest.org/en/6.2.x/fixture.html#fixtures) from this package. The `run_nanorc` object has attributes:
 
 * `completed_process`: [`subprocess.CompletedProcess`](https://docs.python.org/3/library/subprocess.html#subprocess.CompletedProcess) object with the output of the nanorc process
+* `confgen_name`: The name of the configuration generation module used as input to this test
+* `confgen_arguments`: The arguments that were passed to the configuration generation module for this test (useful when running multiple confgens/nanorc sessions as described below)
+* `nanorc_commands`:  The list of commands given to `nanorc` for this test (useful when running multiple confgens/nanorc sessions as described below)
 * `run_dir`:           [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path) pointing to the directory in which nanorc was run
 * `json_dir`:          [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path) pointing to the directory in which the run configuration json files are stored
 * `data_files`:        list of [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path) with each of the HDF5 data files produced by the run

--- a/python/integrationtest/integrationtest_nanorc.py
+++ b/python/integrationtest/integrationtest_nanorc.py
@@ -32,52 +32,70 @@ def pytest_configure(config):
         if p is not None and not file_exists(p):
             pytest.exit(f"{opt} path {p} is not an existing file")
 
-@pytest.fixture(scope="module")
-def setup_dirs(request, tmp_path_factory):
-    """Create the temporary directory to run nanorc in, and put the frame data file in it"""
-    run_dir=tmp_path_factory.mktemp(request.module.__name__+"_run")
-    frame_path=request.config.getoption("--frame-file")
-    os.symlink(frame_path, run_dir.joinpath("frames.bin"))
-    class Dirs:
-        pass
-    dirs=Dirs()
-    dirs.run_dir=run_dir
-    # Form the name of the json directory, but don't actually create
-    # it, because the confgen script checks that it doesn't already
-    # exist
-    p=tmp_path_factory.mktemp(request.module.__name__)
-    dirs.json_dir=p / "json"
-    yield dirs
+def parametrize_fixture_with_list(metafunc, fixture, listname):
+    """Parametrize a fixture using the contents of variable `listname`
+    from module scope. We want to distinguish between the cases where
+    the list is a list of strings, and a list of lists of strings. We
+    do this by checking whether the first item in the list is a
+    string. Not perfect, but better than nothing
+
+    """
+    the_list=getattr(metafunc.module, listname)
+    if type(the_list[0])==str:
+        params=[the_list]
+    else:
+        params=the_list
+    metafunc.parametrize(fixture, params, indirect=True)
+    
+def pytest_generate_tests(metafunc):
+    # We want to be able to run multiple confgens and multiple nanorcs
+    # from one pytest module, but the fixtures for running the
+    # external commands are module-scoped, so we need to parametrize
+    # the fixtures. This could be done by adding "params=..." to the
+    # @pytest.fixture decorator at each fixture, but the user doesn't
+    # have access to that point in the code. So instead we pull
+    # variables from the module (which the user _does_ have access to)
+    # and parametrize the fixtures here in pytest_generate_tests,
+    # which is run at pytest startup
+    parametrize_fixture_with_list(metafunc, "create_json_files", "confgen_arguments")
+    parametrize_fixture_with_list(metafunc, "run_nanorc", "nanorc_command_list")
 
 @pytest.fixture(scope="module")
-def create_json_files(request, setup_dirs):
+def create_json_files(request, tmp_path_factory):
     """Run the confgen to produce the configuration json files
 
-    The name of the module to use is taken from the `confgen_name`
-    variable in the global scope of the test module, and the arguments
-    for the confgen are taken from the `confgen_arguments` variable in
-    the same place
+    The name of the module to use is taken (indirectly) from the
+    `confgen_name` variable in the global scope of the test module,
+    and the arguments for the confgen are taken from the
+    `confgen_arguments` variable in the same place. These variables
+    are converted into parameters for this fixture by the
+    pytest_generate_tests function, to allow multiple confgens to be
+    produced by one pytest module
 
     """
     print("Creating json files")
     module_name=getattr(request.module, "confgen_name")
-    module_arguments=getattr(request.module, "confgen_arguments")
+    module_arguments=request.param
+    
     try:
-        subprocess.run(["python", "-m"] + [module_name] + module_arguments + [str(setup_dirs.json_dir)], check=True)
+        json_dir=tmp_path_factory.mktemp("json", numbered=True) / "json"
+        subprocess.run(["python", "-m"] + [module_name] + module_arguments + [str(json_dir)], check=True)
     except subprocess.CalledProcessError as err:
         print(f"Generating json files failed with exit code {err.returncode}")
         pytest.fail()
+        
+    yield json_dir
 
 @pytest.fixture(scope="module")
-def run_nanorc(request, create_json_files, setup_dirs):
+def run_nanorc(request, create_json_files, tmp_path_factory):
     """Run nanorc with the json files created by `create_json_files`. The
     commands specified by the `nanorc_command_list` variable in the
-    test module are executed
+    test module are executed. If `nanorc_command_list`'s items are
+    themselves lists, then nanorc will be run multiple times, once for
+    each set of arguments in the list
 
     """
-    command_list=getattr(request.module, "nanorc_command_list")
-    run_dir=setup_dirs.run_dir
-    json_dir=setup_dirs.json_dir
+    command_list=request.param
 
     nanorc=request.config.getoption("--nanorc-path")
     if nanorc is None:
@@ -86,10 +104,14 @@ def run_nanorc(request, create_json_files, setup_dirs):
     class RunResult:
         pass
 
+    run_dir=tmp_path_factory.mktemp("run")
+    frame_path=request.config.getoption("--frame-file")
+    os.symlink(frame_path, run_dir.joinpath("frames.bin"))
+    
     result=RunResult()
-    result.completed_process=subprocess.run([nanorc] + [str(json_dir)] + command_list, cwd=run_dir)
+    result.completed_process=subprocess.run([nanorc] + [str(create_json_files)] + command_list, cwd=run_dir)
     result.run_dir=run_dir
-    result.json_dir=json_dir
+    result.json_dir=create_json_files
     result.data_files=list(run_dir.glob("swtest_*.hdf5"))
     result.log_files=list(run_dir.glob("log_*.txt"))
     result.opmon_files=list(run_dir.glob("info_*.json"))


### PR DESCRIPTION
Implemented by parametrizing the fixtures in integrationtest_nanorc.py
"dynamically" using pytest_generate_tests. Required rearranging the
tmp file code a bit, because there were some implicit assumptions that
there would only be one json dir and one output dir. With the result
that setup_dirs became obsolete.
