### PR TITLE
Candidate enhancements to log_file_checks

### DIFF
--- a/python/integrationtest/log_file_checks.py
+++ b/python/integrationtest/log_file_checks.py
@@ -1,8 +1,9 @@
 from glob import glob
 import re
 
-def log_has_no_errors(log_file_name, print_logfilename_for_problems=False, excluded_substring_list=[]):
+def log_has_no_errors(log_file_name, print_logfilename_for_problems=True, excluded_substring_list=[]):
     ok=True
+    ignored_problem_count=0
     for line in open(log_file_name).readlines():
 
         # First check if the line appears to be in the standard format of messages produced with our logging package
@@ -24,42 +25,49 @@ def log_has_no_errors(log_file_name, print_logfilename_for_problems=False, exclu
         if bad_line:
             ignore_this_problem=False
             for excluded_substring in excluded_substring_list:
-                if excluded_substring in line:
+                match_obj = re.search(excluded_substring, line)
+                if match_obj:
                     ignore_this_problem=True
                     break
             if ignore_this_problem:
                 bad_line=False
+                ignored_problem_count+=1
         if bad_line:
             if ok and print_logfilename_for_problems:
                 print("----------")
                 print(f"Problem(s) found in logfile {log_file_name}:")
             print(line)
             ok=False
+    if ignored_problem_count > 0:
+        print(f"Note: problems found in {ignored_problem_count} lines in {log_file_name} were ignored based on {len(excluded_substring_list)} phrase(s).")
     return ok
 
-# 14-Nov-2021, KAB: added the ability for users to specify sets of excluded substrings, to
+# 23-Nov-2021, KAB: added the ability for users to specify sets of excluded substrings, to
 # enable checking of all log files, and to print out the logfile name when there are problems.
 #
 # This function accepts the following arguments:
 # * the list of logfiles to be checked (array of PythonPath objects)
-# * a flag to control whether all logfiles are checked for problems or checking stops as
-#   soon as one file with problems is found (default is to stop after the first one)
+# * a flag to control whether all logfiles are checked for problems or whether checking
+#   stops as soon as one file with problems is found (default is to check them all)
 # * a flag to control whether the logfile name is printed to the console when an a problem
-#   is first found in that logfile (default is no printout)
+#   is first found in that logfile (default is printout)
 # * the sets of excluded substrings.  This goal of this argument is to allow certain
 #   select messages to be ignored so that overall checking of logfiles can remain enabled
 #   without being distracted by 'expected' problems.  This argument is expected to be a
 #   dictionary keyed by strings that might appear in the logfile name and having values
-#   that are lists of excluded phrases. For example:
+#   that are lists of excluded phrases.  Both the logfile name key and the excluded phrases
+#   support regular expressions.  Use r"<regex_pattern>" to handle any special patterns.
+#   For example:
 #   ex_sub_map = {"ruemu": ["expected problem phrase 1", "expected problem  phrase 2"]}
-def logs_are_error_free(log_file_names, show_all_problems=False, print_logfilename_for_problems=False,
+#   ex_sub_map = {"ruemu": [r"expected problem phrase \d+"]}
+def logs_are_error_free(log_file_names, show_all_problems=True, print_logfilename_for_problems=True,
                         excluded_substring_map={}):
     all_ok=True
     for log in log_file_names:
         exclusion_found=False
         for exclusion_key in excluded_substring_map.keys():
-            if exclusion_key in log.name:
-                print(f"Note: {len(excluded_substring_map[exclusion_key])} phrase(s) will be ignored when checking for problems in {log}")
+            match_obj = re.search(exclusion_key, log.name)
+            if match_obj:
                 single_ok=log_has_no_errors(log, print_logfilename_for_problems,
                                             excluded_substring_map[exclusion_key])
                 exclusion_found=True

--- a/python/integrationtest/log_file_checks.py
+++ b/python/integrationtest/log_file_checks.py
@@ -1,31 +1,74 @@
 from glob import glob
 import re
 
-def log_has_no_errors(log_file_name):
+def log_has_no_errors(log_file_name, print_logfilename_for_problems=False, excluded_substring_list=[]):
     ok=True
     for line in open(log_file_name).readlines():
 
         # First check if the line appears to be in the standard format of messages produced with our logging package
         # For lines produced with our logging package, the first two words in the line are the date and time, then the severity
 
+        bad_line=False
         match_logline_prefix = re.search(r"^20[0-9][0-9]-[A-Z][a-z][a-z]-[0-9]+\s+[0-9:,]+\s+([A-Z]+)", line)
         if match_logline_prefix:
             severity=match_logline_prefix.group(1)
             if severity in ("WARN", "ERROR", "FATAL"):
-                print(line)
-                ok=False
+                bad_line=True
         else: # This line's not produced with our logging package, so let's just look for bad words
             if "WARN" in line or "Warn" in line or "warn" in line or \
                "ERROR" in line or "Error" in line or "error" in line or \
                "FATAL" in line or "Fatal" in line or "fatal" in line or \
                "egmentation fault" in line:
-                print(line)
-                ok=False
-            
+                bad_line=True
+
+        if bad_line:
+            ignore_this_problem=False
+            for excluded_substring in excluded_substring_list:
+                if excluded_substring in line:
+                    ignore_this_problem=True
+                    break
+            if ignore_this_problem:
+                bad_line=False
+        if bad_line:
+            if ok and print_logfilename_for_problems:
+                print("----------")
+                print(f"Problem(s) found in logfile {log_file_name}:")
+            print(line)
+            ok=False
     return ok
 
-def logs_are_error_free(log_file_names):
+# 14-Nov-2021, KAB: added the ability for users to specify sets of excluded substrings, to
+# enable checking of all log files, and to print out the logfile name when there are problems.
+#
+# This function accepts the following arguments:
+# * the list of logfiles to be checked (array of PythonPath objects)
+# * a flag to control whether all logfiles are checked for problems or checking stops as
+#   soon as one file with problems is found (default is to stop after the first one)
+# * a flag to control whether the logfile name is printed to the console when an a problem
+#   is first found in that logfile (default is no printout)
+# * the sets of excluded substrings.  This goal of this argument is to allow certain
+#   select messages to be ignored so that overall checking of logfiles can remain enabled
+#   without being distracted by 'expected' problems.  This argument is expected to be a
+#   dictionary keyed by strings that might appear in the logfile name and having values
+#   that are lists of excluded phrases. For example:
+#   ex_sub_map = {"ruemu": ["expected problem phrase 1", "expected problem  phrase 2"]}
+def logs_are_error_free(log_file_names, show_all_problems=False, print_logfilename_for_problems=False,
+                        excluded_substring_map={}):
     all_ok=True
     for log in log_file_names:
-        all_ok=all_ok and log_has_no_errors(log)
+        exclusion_found=False
+        for exclusion_key in excluded_substring_map.keys():
+            if exclusion_key in log.name:
+                print(f"Note: {len(excluded_substring_map[exclusion_key])} phrase(s) will be ignored when checking for problems in {log}")
+                single_ok=log_has_no_errors(log, print_logfilename_for_problems,
+                                            excluded_substring_map[exclusion_key])
+                exclusion_found=True
+                break
+        if not exclusion_found:
+            single_ok=log_has_no_errors(log, print_logfilename_for_problems)
+
+        if not single_ok:
+            all_ok=False
+            if not show_all_problems:
+                break
     return all_ok

--- a/python/integrationtest/log_file_checks.py
+++ b/python/integrationtest/log_file_checks.py
@@ -13,7 +13,7 @@ def log_has_no_errors(log_file_name, print_logfilename_for_problems=True, exclud
         match_logline_prefix = re.search(r"^20[0-9][0-9]-[A-Z][a-z][a-z]-[0-9]+\s+[0-9:,]+\s+([A-Z]+)", line)
         if match_logline_prefix:
             severity=match_logline_prefix.group(1)
-            if severity in ("WARN", "ERROR", "FATAL"):
+            if severity in ("WARNING", "ERROR", "FATAL"):
                 bad_line=True
         else: # This line's not produced with our logging package, so let's just look for bad words
             if "WARN" in line or "Warn" in line or "warn" in line or \


### PR DESCRIPTION
Last week, during the testing of the changes that we made to split out the DQM process from the Readout process, I noticed some changes in the log_file_checks function that I would have found helpful.  This PR has candidate implementations for those changes.

1. The existing logic in the `logs_are_error_free` function (`all_ok=all_ok and log_has_no_errors(log)`) would stop checking for errors after the first logfile in which there was an error.  I would have found it helpful for the test to check *all* logfiles, so I've added a flag (`show_all_problems`) to enable that behavior.
2. I would find it helpful to know which logfile contained which errors, so I added a flag to enable the printout of the logfile name when there is one or more errors in a logfile.
3. It would be *very* helpful to be able to tell the `log_file_check` function to ignore certain 'expected' problems.  This is implemented in the  new `excluded_substring_map` argument.